### PR TITLE
[DAT-22140] Rename master branch references to main

### DIFF
--- a/templates/liquibase-dry-run.nuspec.TEMPLATE
+++ b/templates/liquibase-dry-run.nuspec.TEMPLATE
@@ -14,7 +14,7 @@ Liquibase is an open source, database-independent library for tracking, managing
     <tags>db change management</tags>
     <licenseUrl>https://github.com/liquibase/liquibase/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.githubusercontent.com/liquibase/liquibase-chocolatey/master/liquibase.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/liquibase/liquibase-chocolatey/main/liquibase.png</iconUrl>
     <packageSourceUrl>https://github.com/liquibase/liquibase-chocolatey</packageSourceUrl>
     <docsUrl>http://www.liquibase.org/documentation/index.html</docsUrl>
     <bugTrackerUrl>https://liquibase.jira.com/</bugTrackerUrl>

--- a/templates/liquibase-secure.nuspec.TEMPLATE
+++ b/templates/liquibase-secure.nuspec.TEMPLATE
@@ -14,7 +14,7 @@ Liquibase Secure is the enterprise-grade edition of Liquibase that provides adva
     <tags>db change management secure enterprise liquibase</tags>
     <licenseUrl>https://github.com/liquibase/liquibase/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.githubusercontent.com/liquibase/liquibase-secure-chocolatey/master/liquibase.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/liquibase/liquibase-secure-chocolatey/main/liquibase.png</iconUrl>
     <packageSourceUrl>https://github.com/liquibase/liquibase-secure-chocolatey</packageSourceUrl>
     <releaseNotes>https://github.com/liquibase/liquibase/releases/tag/v@LIQUIBASE_VERSION@</releaseNotes>
     <docsUrl>https://docs.liquibase.com/</docsUrl>


### PR DESCRIPTION
## Summary
- Update `iconUrl` in `liquibase-secure.nuspec.TEMPLATE` to reference `main` branch (this repo)
- Update `iconUrl` in `liquibase-dry-run.nuspec.TEMPLATE` to reference `main` branch (`liquibase-chocolatey` repo, already migrated)

## Skipped References
- `licenseUrl` pointing to `liquibase/liquibase/blob/master/LICENSE.txt` in both templates -- the `liquibase/liquibase` repo still uses `master` as its default branch

## Test Plan
- [ ] Verify iconUrl resolves correctly after branch rename

Jira: [DAT-22140](https://datical.atlassian.net/browse/DAT-22140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)